### PR TITLE
Add finetuning yaml links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please see the [vLLM docs](https://docs.vllm.ai/en/latest/) for instructions on 
 
 To finetune DBRX with our open source library [LLM Foundry](https://www.github.com/mosaicml/llm-foundry), please see the instructions in our training script (found [here](https://github.com/mosaicml/llm-foundry/tree/main/scripts/train)). We have finetuning support for both:
 * Full parameter finetuning, see the yaml config [dbrx-full-ft.yaml](https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/yamls/finetune/dbrx-full-ft.yaml)
-* LORA finetuning, see the yaml config [dbrx-lora-ft.yaml](https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/yamls/finetune/dbrx-lora-ft.yaml)
+* LoRA finetuning, see the yaml config [dbrx-lora-ft.yaml](https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/yamls/finetune/dbrx-lora-ft.yaml)
 
 Note: LORA support currently cannot finetune the experts, since the experts are fused. Stay tuned for more.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ After merging, instructions to build and run DBRX TensorRT engines will be found
 
 Please see the [vLLM docs](https://docs.vllm.ai/en/latest/) for instructions on how to run DBRX with the vLLM engine.
 
+### MLX
+
+If you have an Apple laptop with a sufficiently powerful M-series chip, quantized version of DBRX can be run with MLX. See instructions for running DBRX on MLX [here](https://huggingface.co/mlx-community/dbrx-instruct-4bit).
+
 ## Finetune
 
 To finetune DBRX with our open source library [LLM Foundry](https://www.github.com/mosaicml/llm-foundry), please see the instructions in our training script (found [here](https://github.com/mosaicml/llm-foundry/tree/main/scripts/train)). We have finetuning support for both:
@@ -77,6 +81,10 @@ The model cards can be found at:
 DBRX is available on the Databricks platform through:
 * [Mosaic AI Model Serving](https://docs.databricks.com/machine-learning/foundation-models/supported-models.html#dbrx-instruct)
 * [Mosaic AI Playground](https://docs.databricks.com/en/large-language-models/ai-playground.html)
+
+Other providers have recently added support for DBRX:
+* [You.com](https://you.com/)
+* [Perplexity Labs](https://labs.perplexity.ai/)
 
 The same tools used to train high quality MoE models such as DBRX are available for Databricks customers. Please reach out to us at https://www.databricks.com/company/contact if you are interested in pre-training, finetuning, or deploying your own DBRX models!
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To finetune DBRX with our open source library [LLM Foundry](https://www.github.c
 * Full parameter finetuning, see the yaml config [dbrx-full-ft.yaml](https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/yamls/finetune/dbrx-full-ft.yaml)
 * LoRA finetuning, see the yaml config [dbrx-lora-ft.yaml](https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/yamls/finetune/dbrx-lora-ft.yaml)
 
-Note: LORA support currently cannot finetune the experts, since the experts are fused. Stay tuned for more.
+Note: LoRA support currently cannot finetune the experts, since the experts are fused. Stay tuned for more.
 
 ## Model card
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ Please see the [vLLM docs](https://docs.vllm.ai/en/latest/) for instructions on 
 
 ## Finetune
 
-An example script to finetune DBRX can be found in our open source library [LLM Foundry](https://www.github.com/mosaicml/llm-foundry)
+To finetune DBRX with our open source library [LLM Foundry](https://www.github.com/mosaicml/llm-foundry), please see the instructions in our training script (found [here](https://github.com/mosaicml/llm-foundry/tree/main/scripts/train)). We have finetuning support for both:
+* Full parameter finetuning, see the yaml config [dbrx-full-ft.yaml](https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/yamls/finetune/dbrx-full-ft.yaml)
+* LORA finetuning, see the yaml config [dbrx-lora-ft.yaml](https://github.com/mosaicml/llm-foundry/blob/main/scripts/train/yamls/finetune/dbrx-lora-ft.yaml)
 
+Note: LORA support currently cannot finetune the experts, since the experts are fused. Stay tuned for more.
 
 ## Model card
 


### PR DESCRIPTION
This PR adds links to the hard-to-find dbrx finetuning yamls in LLM Foundry.