### PR TITLE
 Bump torch to 2.1.0

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,4 +1,4 @@
-torch>=2.0.1
+torch>=2.1.0
 transformers>=4.39.0
 accelerate==0.28.0
 flash-attn==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=2.0.1
+torch>=2.1.0
 transformers>=4.39.0
 accelerate==0.28.0
 tiktoken==0.4.0


### PR DESCRIPTION
Our `modeling_dbrx.py` uses `nn.LayerNorm(... bias=False)` , e.g. https://huggingface.co/databricks/dbrx-instruct/blob/main/modeling_dbrx.py#L642

This was introduced in Torch 2.1 (e.g. missing from [torch 2.0 docs](https://pytorch.org/docs/2.0/generated/torch.nn.LayerNorm.html?highlight=layernorm#torch.nn.LayerNorm)), so bumping the minimum requirements here to torch 2.1.